### PR TITLE
[Fix]: api path 수정

### DIFF
--- a/src/main/java/com/pytorch/gradingx/controller/AssignmentController.java
+++ b/src/main/java/com/pytorch/gradingx/controller/AssignmentController.java
@@ -22,7 +22,7 @@ public class AssignmentController {
     }
 
     @PostMapping
-    public ResponseEntity createAssignment(@RequestBody AssignmentCreateRequest assignmentCreateRequest){
+    public ResponseEntity<Long> createAssignment(@RequestBody AssignmentCreateRequest assignmentCreateRequest){
         return ResponseEntity.ok().build();
     }
 
@@ -32,8 +32,8 @@ public class AssignmentController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping
-    public ResponseEntity deleteAssignment(@RequestParam long assignmentId){
+    @DeleteMapping("/{assignmentId}")
+    public ResponseEntity deleteAssignment(@PathVariable long assignmentId){
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/pytorch/gradingx/controller/AssignmentController.java
+++ b/src/main/java/com/pytorch/gradingx/controller/AssignmentController.java
@@ -11,25 +11,24 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/assignment")
 public class AssignmentController {
 
-    @PostMapping("/create")
+    @GetMapping
+    public ResponseEntity<AssignmentListResponse> findAssignmentList(){
+        return ResponseEntity.ok(new AssignmentListResponse());
+    }
+
+    @GetMapping("/{assignmentId}")
+    public ResponseEntity<AssignmentInfoResponse> getAssignmentInfo(@PathVariable long assignmentId){
+        return ResponseEntity.ok(new AssignmentInfoResponse());
+    }
+
+    @PostMapping
     public ResponseEntity createAssignment(@RequestBody AssignmentCreateRequest assignmentCreateRequest){
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/list")
-    public ResponseEntity<AssignmentListResponse> findAssignmentList(@RequestParam(required = false) long courseId,
-                                                                    @RequestParam(required = false) String guestEmail){
-        return ResponseEntity.ok(new AssignmentListResponse());
-    }
 
-    @GetMapping("/info")
-    public ResponseEntity<AssignmentInfoResponse> getAssignmentInfo(@RequestParam long assignmentId){
-        return ResponseEntity.ok(new AssignmentInfoResponse());
-    }
-
-
-    @PostMapping("/update")
-    public ResponseEntity updateAssignmentInfo(@RequestBody AssignmentUpdateRequest assignmentUpdateRequest){
+    @PutMapping("/{assignmentId}")
+    public ResponseEntity updateAssignmentInfo(@PathVariable long assignmentId, @RequestBody AssignmentUpdateRequest assignmentUpdateRequest){
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/pytorch/gradingx/controller/AuthController.java
+++ b/src/main/java/com/pytorch/gradingx/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.pytorch.gradingx.controller;
 
+import com.pytorch.gradingx.dto.auth.LoginRequest;
+import com.pytorch.gradingx.dto.auth.SignupRequest;
 import com.pytorch.gradingx.dto.auth.TokenRequest;
 import com.pytorch.gradingx.dto.auth.TokenResponse;
 import org.springframework.http.ResponseEntity;
@@ -8,18 +10,18 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
-    @GetMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestParam String id, @RequestParam String pw){
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request){
         return ResponseEntity.ok(new TokenResponse());
     }
 
-    @GetMapping("/reissue")
+    @PostMapping("/reissue")
     public ResponseEntity<String> reissueAccessToken(@RequestBody TokenRequest token){
         return ResponseEntity.ok("");
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<TokenResponse> signup(@RequestBody TokenRequest token){
+    public ResponseEntity<TokenResponse> signup(@RequestBody SignupRequest request){
         return ResponseEntity.ok(new TokenResponse());
     }
 }

--- a/src/main/java/com/pytorch/gradingx/controller/MemberController.java
+++ b/src/main/java/com/pytorch/gradingx/controller/MemberController.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/member")
 public class MemberController {
 
-    @GetMapping("/info")
+    @GetMapping
     public ResponseEntity<MemberInfoResponse> getMemberInfo(){
         return ResponseEntity.ok(new MemberInfoResponse());
     }
 
-    @PostMapping("/update")
+    @PutMapping
     public ResponseEntity updateMemberInfo(@RequestBody MemberUpdateRequest memberUpdateRequest){
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/pytorch/gradingx/domain/enumeration/MemberType.java
+++ b/src/main/java/com/pytorch/gradingx/domain/enumeration/MemberType.java
@@ -1,5 +1,5 @@
 package com.pytorch.gradingx.domain.enumeration;
 
 public enum MemberType {
-    Instructor, Student
+    INSTRUCTOR, STUDENT
 }

--- a/src/main/java/com/pytorch/gradingx/dto/assignment/AssignmentInfoResponse.java
+++ b/src/main/java/com/pytorch/gradingx/dto/assignment/AssignmentInfoResponse.java
@@ -1,12 +1,14 @@
 package com.pytorch.gradingx.dto.assignment;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class AssignmentInfoResponse {
+    public long id;
     public String name;
     public String description;
-    public String startTime;
-    public String endTime;
+    public LocalDateTime startTime;
+    public LocalDateTime endTime;
 
     public List<QuestionElement> questions;
 

--- a/src/main/java/com/pytorch/gradingx/dto/assignment/AssignmentUpdateRequest.java
+++ b/src/main/java/com/pytorch/gradingx/dto/assignment/AssignmentUpdateRequest.java
@@ -3,7 +3,6 @@ package com.pytorch.gradingx.dto.assignment;
 import java.time.LocalDateTime;
 
 public class AssignmentUpdateRequest {
-    public long id;
     public String name;
     public String description;
     public LocalDateTime startTime;

--- a/src/main/java/com/pytorch/gradingx/dto/auth/LoginRequest.java
+++ b/src/main/java/com/pytorch/gradingx/dto/auth/LoginRequest.java
@@ -1,0 +1,6 @@
+package com.pytorch.gradingx.dto.auth;
+
+public class LoginRequest {
+    public String email;
+    public String password;
+}

--- a/src/main/java/com/pytorch/gradingx/dto/auth/TokenRequest.java
+++ b/src/main/java/com/pytorch/gradingx/dto/auth/TokenRequest.java
@@ -1,6 +1,6 @@
 package com.pytorch.gradingx.dto.auth;
 
 public class TokenRequest {
-    public String AccessToken;
-    public String RefreshToken;
+    public String accessToken;
+    public String refreshToken;
 }

--- a/src/main/java/com/pytorch/gradingx/dto/member/MemberUpdateRequest.java
+++ b/src/main/java/com/pytorch/gradingx/dto/member/MemberUpdateRequest.java
@@ -1,9 +1,10 @@
 package com.pytorch.gradingx.dto.member;
 
+import com.pytorch.gradingx.domain.enumeration.MemberType;
+
 public class MemberUpdateRequest {
-    public long id;
     public String email;
     public String name;
     public String password;
-    public String memberType;
+    public MemberType memberType;
 }


### PR DESCRIPTION
# Work Description
- RestAPI 규격에 맞지 않는 api path를 수정
- enum에 파스칼케이스를 수정


### 이슈사항
- courseId, guestEmail가 어디에 사용되는지 모르겠어서 삭제했습니다.
```
@GetMapping("/list")
    public ResponseEntity<AssignmentListResponse> findAssignmentList(@RequestParam(required = false) long courseId,
                                                                    @RequestParam(required = false) String guestEmail){
        return ResponseEntity.ok(new AssignmentListResponse());
    }
```